### PR TITLE
chore: rename CLI binary to nirman-cli

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -139,3 +139,4 @@ dist
 # Vite logs files
 vite.config.js.timestamp-*
 vite.config.ts.timestamp-*
+project-root/


### PR DESCRIPTION
## Summary
This PR renames the executable binary from `nirman` to `nirman-cli` to avoid conflicts with VS Code/Windsurf system commands.

### Changes
- Updated `package.json` bin field
- Verified CLI runs correctly via `npx nirman-cli`

### Testing
```bash
npm link
npx nirman-cli sample.md --dry-run -o output_dir
```

Closes #3 